### PR TITLE
Fjern flexmember fra topic ACL

### DIFF
--- a/nais/topics/vedtak-status-topic.yaml
+++ b/nais/topics/vedtak-status-topic.yaml
@@ -27,6 +27,3 @@ spec:
     - team: flex
       application: spinnsyn-arkivering
       access: read
-    - team: flex
-      application: flexmember
-      access: read


### PR DESCRIPTION
Brukt ved reset av Kafka topic offset reset og trengs ikke mer.