### PR TITLE
Dependabot updates

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,13 +29,13 @@ jobs:
           path: VERSION.txt
       - name: Gradle wrapper validation
         uses: gradle/wrapper-validation-action@v1
-      - uses: actions/cache@v2.1.6
+      - uses: actions/cache@v2.1.7
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-cache-${{ hashFiles('build.gradle.kts') }}
           restore-keys: |
             ${{ runner.os }}-gradle-cache-
-      - uses: actions/cache@v2.1.6
+      - uses: actions/cache@v2.1.7
         with:
           path: ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,7 +44,7 @@ repositories {
 }
 
 val testContainersVersion = "1.16.2"
-val logstashLogbackEncoderVersion = "6.6"
+val logstashLogbackEncoderVersion = "7.0.1"
 val kluentVersion = "1.68"
 val brukernotifikasjonAvroVersion = "2.3.1"
 val confluentVersion = "7.0.0"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,7 +46,7 @@ repositories {
 val testContainersVersion = "1.16.2"
 val logstashLogbackEncoderVersion = "6.6"
 val kluentVersion = "1.68"
-val brukernotifikasjonAvroVersion = "1.2021.01.18-11.12-b9c8c40b98d1"
+val brukernotifikasjonAvroVersion = "2.3.1"
 val confluentVersion = "6.2.0"
 val tokenSupportVersion = "1.3.9"
 val syfoKafkaVersion = "2021.07.20-09.39-6be2c52c"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -47,7 +47,7 @@ val testContainersVersion = "1.16.2"
 val logstashLogbackEncoderVersion = "6.6"
 val kluentVersion = "1.68"
 val brukernotifikasjonAvroVersion = "2.3.1"
-val confluentVersion = "6.2.0"
+val confluentVersion = "7.0.0"
 val tokenSupportVersion = "1.3.9"
 val syfoKafkaVersion = "2021.07.20-09.39-6be2c52c"
 


### PR DESCRIPTION
Samler PRs fra dependabot for testing

- Bump actions/cache from 2.1.6 to 2.1.7 
- Bump logstash-logback-encoder from 6.6 to 7.0.1
- Bump kafka-avro-serializer from 6.2.0 to 7.0.0 
- Bump brukernotifikasjon-schemas from 1.2021.01.18-11.12-b9c8c40b98d1 to 2.3.1
