### PR TITLE
Stopp sending av Done-meldinger ved lesing

### DIFF
--- a/src/main/kotlin/no/nav/helse/flex/service/VedtakStatusService.kt
+++ b/src/main/kotlin/no/nav/helse/flex/service/VedtakStatusService.kt
@@ -75,7 +75,7 @@ class VedtakStatusService(
                     }
 
                     if (alleDager.ingenAndreDager()) {
-                        log.info("Utbetaling $utbetalingId inneholder bare dager der NAV ikke er innvolvert")
+                        log.info("Utbetaling $utbetalingId inneholder bare dager der NAV ikke er involvert")
                     }
 
                     vedtakStatusKafkaProducer.produserMelding(

--- a/src/test/kotlin/no/nav/helse/flex/MergingAvVedtakTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/MergingAvVedtakTest.kt
@@ -215,56 +215,8 @@ class MergingAvVedtakTest : AbstractContainerBaseTest() {
         lesVedtakMedTokenXToken(fnr, vedtaksId) `should be equal to` "Leste vedtak $vedtaksId"
         lesVedtakMedTokenXToken(fnr, vedtaksId) `should be equal to` "Vedtak $vedtaksId er allerede lest"
 
-        val doned = doneKafkaConsumer.ventPåRecords(antall = 1)
-        doned.shouldHaveSize(1)
-
-        val nokkel = doned[0].key()
-        nokkel.getEventId() `should be equal to` vedtaksId
-
-        val done = doned[0].value()
-        done.getFodselsnummer() `should be equal to` fnr
-
         val utbetalingDbRecord = utbetalingRepository.findUtbetalingDbRecordsByFnr(fnr).first { it.id == vedtaksId }
         utbetalingDbRecord.lest.`should not be null`()
         utbetalingDbRecord.varsletMed.`should be equal to`(vedtaksId)
-    }
-
-    @Test
-    @Order(11)
-    fun `verdi i varslet_med feltet brukes til Done-melding`() {
-        val vedtakMedUtbetalingId = hentVedtakMedLoginserviceToken(fnr).first()
-        val vedtakVarselId = vedtakRepository
-            .findVedtakDbRecordsByFnr(fnr)
-            .filter { it.utbetalingId == vedtakMedUtbetalingId.vedtak.utbetaling.utbetalingId }
-            .sortedBy { it.id }
-            .first()
-
-        utbetalingRepository.save(
-            utbetalingRepository
-                .findById(vedtakMedUtbetalingId.id)
-                .get()
-                .copy(
-                    lest = null,
-                    varsletMed = vedtakVarselId.id
-                )
-        )
-
-        lesVedtakMedTokenXToken(fnr, vedtakMedUtbetalingId.id) `should be equal to` "Leste vedtak ${vedtakMedUtbetalingId.id}"
-        lesVedtakMedTokenXToken(
-            fnr,
-            vedtakMedUtbetalingId.id
-        ) `should be equal to` "Vedtak ${vedtakMedUtbetalingId.id} er allerede lest"
-
-        val doned = doneKafkaConsumer.ventPåRecords(antall = 1)
-        doned.shouldHaveSize(1)
-
-        val nokkel = doned[0].key()
-        nokkel.getEventId() `should be equal to` vedtakVarselId.id
-
-        val done = doned[0].value()
-        done.getFodselsnummer() `should be equal to` fnr
-
-        val utbetalingDbRecord = utbetalingRepository.findUtbetalingDbRecordsByFnr(fnr).first { it.id == vedtakMedUtbetalingId.id }
-        utbetalingDbRecord.lest.`should not be null`()
     }
 }

--- a/src/test/kotlin/no/nav/helse/flex/NyeTopicIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/NyeTopicIntegrationTest.kt
@@ -1,12 +1,23 @@
 package no.nav.helse.flex
 
-import no.nav.helse.flex.domene.*
+import no.nav.helse.flex.domene.AnnulleringDto
+import no.nav.helse.flex.domene.UtbetalingUtbetalt
 import no.nav.helse.flex.domene.UtbetalingUtbetalt.UtbetalingdagDto
+import no.nav.helse.flex.domene.VedtakFattetForEksternDto
+import no.nav.helse.flex.domene.tilUtbetalingUtbetalt
+import no.nav.helse.flex.domene.tilVedtakFattetForEksternDto
 import no.nav.helse.flex.kafka.SPORBAR_TOPIC
 import no.nav.helse.flex.kafka.UTBETALING_TOPIC
 import no.nav.helse.flex.kafka.VEDTAK_TOPIC
 import no.nav.helse.flex.organisasjon.Organisasjon
-import org.amshove.kluent.*
+import org.amshove.kluent.`should be`
+import org.amshove.kluent.`should be equal to`
+import org.amshove.kluent.`should be false`
+import org.amshove.kluent.`should be true`
+import org.amshove.kluent.`should not be null`
+import org.amshove.kluent.shouldBeEmpty
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldHaveSize
 import org.apache.kafka.clients.producer.KafkaProducer
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.header.internals.RecordHeader
@@ -263,15 +274,6 @@ class NyeTopicIntegrationTest : AbstractContainerBaseTest() {
         lesVedtakMedTokenXToken(fnr, vedtaksId) `should be equal to` "Leste vedtak $vedtaksId"
 
         lesVedtakMedTokenXToken(fnr, vedtaksId) `should be equal to` "Vedtak $vedtaksId er allerede lest"
-
-        val dones = doneKafkaConsumer.ventPåRecords(antall = 1)
-        dones.shouldHaveSize(1)
-
-        val nokkel = dones[0].key()
-        nokkel.getEventId() `should be equal to` vedtaksId
-
-        val done = dones[0].value()
-        done.getFodselsnummer() `should be equal to` fnr
 
         utbetalingRepository.findUtbetalingDbRecordsByFnr(fnr).first().lest.`should not be null`()
     }

--- a/src/test/kotlin/no/nav/helse/flex/VedtakStatusTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/VedtakStatusTest.kt
@@ -324,8 +324,6 @@ class VedtakStatusTest : AbstractContainerBaseTest() {
         statudDto.id `should be equal to` vedtaksId
         statudDto.fnr `should be equal to` fnr
         statudDto.vedtakStatus `should be equal to` VedtakStatus.LEST
-
-        doneKafkaConsumer.ventPåRecords(antall = 1)
     }
 
     @Test
@@ -419,7 +417,7 @@ class VedtakStatusTest : AbstractContainerBaseTest() {
 
     @Test
     @Order(400)
-    fun `vedtakWrapper der det er ingen dager hvor NAV har vært innvolvert`() {
+    fun `vedtakWrapper der det er ingen dager hvor NAV har vært involvert`() {
         kafkaProducer.send(
             ProducerRecord(
                 UTBETALING_TOPIC,


### PR DESCRIPTION
All meldinger varslet med spinnsyn-backend blir Done-et i batch-jobb. Dette forhindrer duplikate Done-meldinger, både under kjøring av batc- jobb og etterpå.