### PR TITLE
Sett Hikari maxLifetime til 10 minutter

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -15,6 +15,7 @@ spring:
       minimum-idle: 1
       maximum-pool-size: 5
       connection-timeout: 60000
+      max-lifetime: 600000
 
 on-prem-kafka:
   schema-registry-url: ${KAFKA_SCHEMA_REGISTRY_URL}


### PR DESCRIPTION
- The error occurs when the application tries to interact with DB with the old pool of connection(older than DB wait_timeout) which it assumes to be live.
- We strongly recommend setting this value, and it should be several seconds shorter than any database or infrastructure imposed connection time limit.