### PR TITLE
Setter idle-timeout

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -15,6 +15,7 @@ spring:
       minimum-idle: 1
       maximum-pool-size: 5
       connection-timeout: 60000
+      idle-timeout: 300000
       max-lifetime: 600000
 
 on-prem-kafka:


### PR DESCRIPTION
Setter idle-timeout til max-lifetime / 2

This property controls the maximum amount of time that a connection is allowed to sit idle in the pool. This setting only applies when minimumIdle is defined to be less than maximumPoolSize. Idle connections will not be retired once the pool reaches minimumIdle connections. Whether a connection is retired as idle or not is subject to a maximum variation of +30 seconds, and average variation of +15 seconds. A connection will never be retired as idle before this timeout. A value of 0 means that idle connections are never removed from the pool. The minimum allowed value is 10000ms (10 seconds). Default: 600000 (10 minutes)