### PR TITLE
Feilfiks: fjern riktig diagnostisk kontekstverdi (#497)

### DIFF
--- a/src/main/kotlin/no/nav/helse/flex/LogRequestIdFilter.kt
+++ b/src/main/kotlin/no/nav/helse/flex/LogRequestIdFilter.kt
@@ -22,7 +22,7 @@ class LogRequestIdFilter : HttpFilter() {
             }
             filterChain.doFilter(request, response)
         } finally {
-            MDC.remove(X_REQUEST_ID_HEADER)
+            MDC.remove(X_REQUEST_ID_MDC_MARKER)
         }
     }
 }


### PR DESCRIPTION
Det viste seg at feil nøkkel ble fjernet fra den diagnostiske konteksten